### PR TITLE
Skip user access validation on GH login callback

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-  before_action :verify_access!
+  before_action :verify_access!, except: [:github_connect]
 
   def index
     @users = User.all

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-  before_action :verify_access!, except: [:github_connect]
+  before_action :verify_access!, only: [:index, :new, :create]
 
   def index
     @users = User.all


### PR DESCRIPTION
When user does not have admin permissions he can't finish
github account integration. This fix resolves this issue.